### PR TITLE
Check for string inclusion instead of equals comparison

### DIFF
--- a/src/services/helpers/StatusTxUtil.ts
+++ b/src/services/helpers/StatusTxUtil.ts
@@ -41,8 +41,8 @@ export class StatusTxUtil {
             const isValid = payload &&
                 payload.returnResult === 'failure' &&
                 (
-                    payload.resultDescription === 'ERROR: Transaction already in the mempool' ||
-                    payload.resultDescription  === 'ERROR: 257: txn-already-known'
+                    payload.resultDescription.includes('Transaction already in the mempool') ||
+                    payload.resultDescription.includes('257: txn-already-known')
                 )
             return isValid;
         } catch (err) {

--- a/src/services/use_cases/tx/SyncTxStatus.ts
+++ b/src/services/use_cases/tx/SyncTxStatus.ts
@@ -129,7 +129,7 @@ export default class SyncTxStatus extends UseCase {
     });
     // Check various error conditions and check whether we need to resend or halt
     if (status && status.payload && status.payload.returnResult === 'failure' &&
-      status.payload.resultDescription === 'ERROR: No such mempool or blockchain transaction. Use gettransaction for wallet transactions.') {
+      status.payload.resultDescription.includes('No such mempool or blockchain transaction. Use gettransaction for wallet transactions.')) {
         this.logger.info('sync', {
           txid: params.txid,
           trace: 4


### PR DESCRIPTION
We noticed that TAAL's resultDescription does not start with `ERROR:`, this caused TXQ not to work properly when talking to MAPI of TAAL. This fix makes checking for the resultDescription more forgiving by using String.includes() instead of doing an equals comparison.